### PR TITLE
Randomize feature for spectra

### DIFF
--- a/mutyper/cli.py
+++ b/mutyper/cli.py
@@ -12,7 +12,6 @@ import pyfaidx
 from random import choice
 from pyliftover import LiftOver
 from Bio.Seq import reverse_complement
-import pdb
 
 from mutyper import ancestor
 
@@ -169,9 +168,9 @@ def spectra(args):
 
         if args.randomize:
             for variant in vcf:
-            	curr_hap = choice([x for x, y in enumerate(variant.gt_types) 
+            	random_haplotype = choice([x for x, y in enumerate(variant.gt_types) 
             						 for _ in range(y)])
-            	spectra_data[variant.INFO['mutation_type']][curr_hap] += 1.
+            	spectra_data[variant.INFO['mutation_type']][random_haplotype] += 1.
         else:
             for variant in vcf:
                 spectra_data[variant.INFO['mutation_type']] += variant.gt_types

--- a/mutyper/cli.py
+++ b/mutyper/cli.py
@@ -9,8 +9,10 @@ import signal
 import numpy as np
 from shutil import copyfile
 import pyfaidx
+from random import choice
 from pyliftover import LiftOver
 from Bio.Seq import reverse_complement
+import pdb
 
 from mutyper import ancestor
 
@@ -165,8 +167,14 @@ def spectra(args):
         spectra_data = defaultdict(lambda: np.zeros_like(vcf.samples,
                                                          dtype=int))
 
-        for variant in vcf:
-            spectra_data[variant.INFO['mutation_type']] += variant.gt_types
+        if args.randomize:
+            for variant in vcf:
+            	curr_hap = choice([x for x, y in enumerate(variant.gt_types) 
+            						 for _ in range(y)])
+            	spectra_data[variant.INFO['mutation_type']][curr_hap] += 1.
+        else:
+            for variant in vcf:
+                spectra_data[variant.INFO['mutation_type']] += variant.gt_types
 
         spectra = pd.DataFrame(spectra_data,
                                vcf.samples).reindex(sorted(spectra_data),
@@ -295,6 +303,8 @@ def get_parser():
     parser_spectra.add_argument('--population', action='store_true',
                                 help='population-wise spectrum, instead of '
                                      'individual')
+    parser_spectra.add_argument('--randomize', action='store_true',
+    							help='randomly assign mutation to a single haplotype')
     parser_spectra.set_defaults(func=spectra)
 
     # arguments specific to ksfs subcommand
@@ -306,3 +316,6 @@ def get_parser():
 def main(arg_list=None):
     args = get_parser().parse_args(arg_list)
     args.func(args)
+
+if __name__ == '__main__':
+	main()

--- a/mutyper/cli.py
+++ b/mutyper/cli.py
@@ -316,6 +316,3 @@ def get_parser():
 def main(arg_list=None):
     args = get_parser().parse_args(arg_list)
     args.func(args)
-
-if __name__ == '__main__':
-	main()


### PR DESCRIPTION
Added `--randomize` as an optional arg for `spectra`, and added a few lines of code within the `spectra` command to randomly allocate a variant to one of the haplotypes that harbor it