### PR TITLE
Proposed fix to bug #14

### DIFF
--- a/mutyper/ancestor.py
+++ b/mutyper/ancestor.py
@@ -57,7 +57,7 @@ class Ancestor(pyfaidx.Fasta):
     def _reverse_strand(self, chrom: str, pos: int):
         r"""return True if strand_file indicates reverse complementation at
         this site"""
-        closest_idx = bisect.bisect(self.strandedness[chrom], (pos, -1))
+        closest_idx = bisect.bisect(self.strandedness[chrom], (pos, -1)) - 1
         if pos < self.strandedness[chrom][closest_idx][1]:
             return True
         return False

--- a/mutyper/cli.py
+++ b/mutyper/cli.py
@@ -60,7 +60,7 @@ def ancestral_fasta(args):
     for variant in vcf:
         # change variants that are not biallelic SNPs to N bases
         if not (variant.is_snp and len(variant.ALT) == 1):
-            anc[chrom][variant.start:
+            anc[variant.CHROM][variant.start:
                        variant.end] = 'N' * (variant.end - variant.start)
         else:
             out_coords = lo.convert_coordinate(variant.CHROM, variant.start)

--- a/mutyper/cli.py
+++ b/mutyper/cli.py
@@ -66,12 +66,12 @@ def ancestral_fasta(args):
             out_coords = lo.convert_coordinate(variant.CHROM, variant.start)
             # change ambiguously aligning sites to N bases
             if out_coords is None or len(out_coords) != 1:
-                anc[chrom][variant.start] = 'N'
+                anc[variant.CHROM][variant.start] = 'N'
             else:
-                if variant.REF != ref[chrom][variant.start].seq.upper():
+                if variant.REF != ref[variant.CHROM][variant.start].seq.upper():
                     raise ValueError(f'variant reference allele {variant.REF} '
                                      f'mismatches reference sequence '
-                                     f'{ref[chrom][variant.start]}')
+                                     f'{ref[variant.CHROM][variant.start]}')
                 out_chromosome, out_position, out_strand = out_coords[0][:3]
                 out_allele = out[out_chromosome][out_position].seq
                 # if negative strand, take reverse complement base
@@ -79,10 +79,10 @@ def ancestral_fasta(args):
                     out_allele = reverse_complement(out_allele)
                 # and finally, polarize
                 if out_allele.upper() == variant.ALT[0]:
-                    anc[chrom][variant.start] = out_allele
+                    anc[variant.CHROM][variant.start] = out_allele
                 elif out_allele.upper() != variant.REF:
                     # triallelic
-                    anc[chrom][variant.start] = 'N'
+                    anc[variant.CHROM][variant.start] = 'N'
 
 
 def variants(args):


### PR DESCRIPTION
This patch fixes the issue reported in github issue [harrispopgen#14](harrispopgen#14).
The issue originates from bisect.bisect using 1-based indexes, as
shown [here](https://docs.python.org/3.9/library/bisect.html), causing
the script to not extract the index correctly when the variant fall out
or within the last index. Also, it causes to intersect with the wrong
interval in the next if statement, since pointing to the index+1
position in the list.