### PR TITLE
Changed the 'number' type of 'mutation type' to A in the VCF header

### DIFF
--- a/mutyper/cli.py
+++ b/mutyper/cli.py
@@ -154,7 +154,7 @@ def variants(args):
             "ID": "mutation_type",
             "Description": f"ancestral {args.k}-mer mutation type",
             "Type": "Character",
-            "Number": "1",
+            "Number": "A",
         }
     )
     vcf_writer = cyvcf2.Writer("-", vcf)


### PR DESCRIPTION
Changed the 'Number' type of 'mutation type' from '1' to 'A' in the VCF header. This is useful because in the case of merging bi-allelic variants into a single multi-allelic variant in a VCF file, 'Number' type of 1 will overwrite the previous 3mer mutation type, whereas type 'A' will append.