### PR TITLE
issue 36: dealing with missing genotypes with mutyper variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,10 @@ venv.bak/
 manuscript/_build
 scons_output*
 
+# vim temporary files
+*.swp
+*.swo
+
 .DS_Store
 *.fa.fai
 

--- a/mutyper/ancestor.py
+++ b/mutyper/ancestor.py
@@ -10,7 +10,7 @@ import numpy as np
 
 
 class Ancestor(pyfaidx.Fasta):
-    r"""ancestral state of a chromosome.
+    r"""Ancestral state of a chromosome.
 
     Args:
         fasta: path to ancestral sequence FASTA
@@ -68,7 +68,7 @@ class Ancestor(pyfaidx.Fasta):
             self._revcomp_func = self._reverse_strand
 
     def _reverse_strand(self, chrom: str, pos: int):
-        r"""return True if strand_file indicates reverse complementation at
+        r"""Return ``True`` if ``strand_file`` indicates reverse complementation at
         this site."""
         closest_idx = bisect.bisect(self.strandedness[chrom][:, 0], pos) - 1
         if closest_idx != -1 and pos < self.strandedness[chrom][closest_idx, 1]:
@@ -76,7 +76,7 @@ class Ancestor(pyfaidx.Fasta):
         return False
 
     def _AC(self, chrom: str, pos: int):
-        r"""return True if reverse complementation is needed at this site to
+        r"""Return True if reverse complementation is needed at this site to
         get state A or C."""
         if self[chrom][pos].seq not in self.ac:
             return True
@@ -85,7 +85,7 @@ class Ancestor(pyfaidx.Fasta):
     def mutation_type(
         self, chrom: str, pos: int, ref: str, alt: str
     ) -> Tuple[str, str]:
-        r"""mutation type of a given snp, oriented or collapsed by strand,
+        r"""Mutation type of a given snp, oriented or collapsed by strand,
         returns a tuple of ancestral and derived kmers.
 
         Args:
@@ -124,9 +124,9 @@ class Ancestor(pyfaidx.Fasta):
     def region_contexts(
         self, chrom: str, start: int = None, end: int = None
     ) -> Generator[str, None, None]:
-        r"""ancestral context of each site in a BED style region (0-based, half-
+        r"""Ancestral context of each site in a BED style region (0-based, half-
         open), oriented according to self.strandedness or collapsed by reverse
-        complementation (returns None if ancestral state at target not in
+        complementation (returns ``None`` if ancestral state at target not in
         capital ACGT)
 
         Args:
@@ -165,7 +165,7 @@ class Ancestor(pyfaidx.Fasta):
             yield context
 
     def targets(self, bed: Union[str, TextIO] = None) -> Dict[str, int]:
-        r"""return a dictionary of the number of sites of each k-mer.
+        r"""Return a dictionary of the number of sites of each k-mer.
 
         Args:
             bed: optional path to BED mask file, or I/O object

--- a/mutyper/ancestor.py
+++ b/mutyper/ancestor.py
@@ -10,7 +10,7 @@ import numpy as np
 
 
 class Ancestor(pyfaidx.Fasta):
-    r"""ancestral state of a chromosome
+    r"""ancestral state of a chromosome.
 
     Args:
         fasta: path to ancestral sequence FASTA
@@ -69,15 +69,15 @@ class Ancestor(pyfaidx.Fasta):
 
     def _reverse_strand(self, chrom: str, pos: int):
         r"""return True if strand_file indicates reverse complementation at
-        this site"""
+        this site."""
         closest_idx = bisect.bisect(self.strandedness[chrom][:, 0], pos) - 1
         if closest_idx != -1 and pos < self.strandedness[chrom][closest_idx, 1]:
             return True
         return False
 
     def _AC(self, chrom: str, pos: int):
-        r"""return True if reverse complementation is needed at this site
-        to get state A or C"""
+        r"""return True if reverse complementation is needed at this site to
+        get state A or C."""
         if self[chrom][pos].seq not in self.ac:
             return True
         return False
@@ -86,7 +86,7 @@ class Ancestor(pyfaidx.Fasta):
         self, chrom: str, pos: int, ref: str, alt: str
     ) -> Tuple[str, str]:
         r"""mutation type of a given snp, oriented or collapsed by strand,
-        returns a tuple of ancestral and derived kmers
+        returns a tuple of ancestral and derived kmers.
 
         Args:
             chrom: FASTA record chromosome identifier
@@ -124,10 +124,10 @@ class Ancestor(pyfaidx.Fasta):
     def region_contexts(
         self, chrom: str, start: int = None, end: int = None
     ) -> Generator[str, None, None]:
-        r"""ancestral context of each site in a BED style region (0-based,
-        half-open), oriented according to self.strandedness or collapsed by
-        reverse complementation (returns None if ancestral state at target not
-        in capital ACGT)
+        r"""ancestral context of each site in a BED style region (0-based, half-
+        open), oriented according to self.strandedness or collapsed by reverse
+        complementation (returns None if ancestral state at target not in
+        capital ACGT)
 
         Args:
             chrom: chromosome name
@@ -165,10 +165,11 @@ class Ancestor(pyfaidx.Fasta):
             yield context
 
     def targets(self, bed: Union[str, TextIO] = None) -> Dict[str, int]:
-        r"""return a dictionary of the number of sites of each k-mer
+        r"""return a dictionary of the number of sites of each k-mer.
 
         Args:
-            bed: optional path to BED mask file, or I/O object"""
+            bed: optional path to BED mask file, or I/O object
+        """
         sizes = Counter()
         if bed is None:
             for chrom in self.keys():

--- a/mutyper/cli.py
+++ b/mutyper/cli.py
@@ -170,6 +170,13 @@ def variants(args):
                 f"invalid ploidy {variant.ploidy}, diploids and haploids only"
             )
 
+        # checks that all genotype elements are from the set of {-1,0,1}
+        # each element in the last column is a 0,1 indicator for phasing status
+        genotype_array = variant.genotype.array()
+        unique_gts = set(np.unique(genotype_array[:, :-1]))
+        if not unique_gts <= set([-1, 0, 1]):
+            raise ValueError(f"invalid genotypes {unique_gts - set([-1,0,1])}")
+
         # mutation type as ancestral kmer and derived kmer
         anc_kmer, der_kmer = ancestor.mutation_type(
             variant.CHROM, variant.start, variant.REF, variant.ALT[0]
@@ -187,12 +194,6 @@ def variants(args):
             variant.INFO["AC"] = variant.INFO["AN"] - variant.INFO["AC"]
             variant.INFO["AF"] = variant.INFO["AC"] / variant.INFO["AN"]
 
-            genotype_array = variant.genotype.array()
-            # checks that all genotype elements are from the set of {-1,0,1}
-            # each element in the last column is a 0,1 indicator for phasing status
-            unique_gts = set(np.unique(genotype_array[:, :-1]))
-            if not unique_gts <= set([-1, 0, 1]):
-                raise ValueError(f"invalid genotypes {unique_gts - set([-1,0,1])}")
             # cyvcf2 docs say we need to reassign genotypes like this for the
             # change to propagate (can't just update indexwise)
             genotype_array[:, :-1] = np.select(

--- a/mutyper/cli.py
+++ b/mutyper/cli.py
@@ -185,14 +185,14 @@ def variants(args):
                 # diploid
                 genotype_array = variant.genotype.array()
                 # missing genotype will get converted from -1 -> 2
-                genotype_array[:,:2] = 1 - genotype_array[:,:2]
-                genotype_array[:,:2][genotype_array[:,:2] == 2] = -1
+                genotype_array[:, :2] = 1 - genotype_array[:, :2]
+                genotype_array[:, :2][genotype_array[:, :2] == 2] = -1
                 variant.genotypes = genotype_array
             elif variant.ploidy == 1:
                 # haploid
                 genotype_array = variant.genotype.array()
-                genotype_array[:,0] = 1 - genotype_array[:,0]
-                genotype_array[:,0][genotype_array[:,0] == 2] = -1
+                genotype_array[:, 0] = 1 - genotype_array[:, 0]
+                genotype_array[:, 0][genotype_array[:, 0] == 2] = -1
             else:
                 raise ValueError(f"invalid ploidy {variant.ploidy}")
 

--- a/mutyper/cli.py
+++ b/mutyper/cli.py
@@ -186,13 +186,13 @@ def variants(args):
                 genotype_array = variant.genotype.array()
                 # missing genotype will get converted from -1 -> 2
                 genotype_array[:,:2] = 1 - genotype_array[:,:2]
-                genotype_array[:,:2][genotype_array[:,:2]==2] = -1
+                genotype_array[:,:2][genotype_array[:,:2] == 2] = -1
                 variant.genotypes = genotype_array
             elif variant.ploidy == 1:
                 # haploid
                 genotype_array = variant.genotype.array()
                 genotype_array[:,0] = 1 - genotype_array[:,0]
-                genotype_array[:,0][genotype_array[:,0]==2] = -1
+                genotype_array[:,0][genotype_array[:,0] == 2] = -1
             else:
                 raise ValueError(f"invalid ploidy {variant.ploidy}")
 
@@ -212,6 +212,7 @@ def variants(args):
 
     if num_vars == 0:
         logging.warning("No variants processed. Check that input vcf is not empty.")
+
 
 def targets(args):
     """subroutine for targets subcommand."""

--- a/mutyper/cli.py
+++ b/mutyper/cli.py
@@ -16,8 +16,8 @@ from mutyper import ancestor
 
 
 def setup_ancestor(args):
-    """utility for initializing an Ancestor object for use in different '
-    'subroutines."""
+    """Utility for initializing an Ancestor object for use in different 
+    subroutines."""
     return ancestor.Ancestor(
         args.fasta,
         k=args.k,
@@ -30,7 +30,7 @@ def setup_ancestor(args):
 
 
 def is_compressed(file):
-    """returns true if file is compressed."""
+    """Returns ``True`` if file is compressed."""
     f = open(file, "rb")
     # The first two bytes of a gzip file are: 1f 8b
     compressed = f.read(2) == b"\x1f\x8b"
@@ -40,7 +40,7 @@ def is_compressed(file):
 
 
 def copy_fasta(file, outfile):
-    """copy fasta file to outfile and decompress if needed.
+    """Copy FASTA file to ``outfile`` and decompress if needed.
 
     This is necessary because pyfaidx does not support mutable
     compressed, so we cannot just copy the input if compressed.
@@ -59,7 +59,7 @@ def copy_fasta(file, outfile):
 
 
 def ancestral_fasta(args):
-    """subroutine for ancestor subcommand."""
+    """Subroutine for ancestor subcommand."""
     # single chromosome fasta file for reference genome
     ref = pyfaidx.Fasta(args.reference, read_ahead=10000)
     # make a copy to build our ancestor for this chromosome
@@ -144,7 +144,7 @@ def ancestral_fasta(args):
 
 
 def variants(args):
-    """subroutine for variants subcommand."""
+    """Subroutine for variants subcommand."""
     ancestor = setup_ancestor(args)
 
     vcf = cyvcf2.VCF(args.vcf)
@@ -217,7 +217,7 @@ def variants(args):
 
 
 def targets(args):
-    """subroutine for targets subcommand."""
+    """Subroutine for targets subcommand."""
     ancestor = setup_ancestor(args)
 
     if args.bed == "-":
@@ -233,7 +233,7 @@ def targets(args):
 
 
 def spectra(args):
-    """subroutine for spectra subcommand."""
+    """Subroutine for spectra subcommand."""
 
     vcf = cyvcf2.VCF(args.vcf, strict_gt=True)
 
@@ -287,7 +287,7 @@ def spectra(args):
 
 
 def ksfs(args):
-    """subroutine for ksfs subcommand."""
+    """Subroutine for ksfs subcommand."""
     vcf = cyvcf2.VCF(args.vcf)
 
     ksfs_data = defaultdict(lambda: Counter())

--- a/mutyper/cli.py
+++ b/mutyper/cli.py
@@ -14,7 +14,6 @@ from Bio.Seq import reverse_complement
 import logging
 import gzip
 from mutyper import ancestor
-from time import sleep
 
 
 def setup_ancestor(args):

--- a/mutyper/cli.py
+++ b/mutyper/cli.py
@@ -157,8 +157,6 @@ def variants(args):
             "Number": "A",
         }
     )
-    # vcf_writer = cyvcf2.Writer("-", vcf)
-    # vcf_writer.write_header()
     print(vcf.raw_header, end="")
     num_vars = 0
     for variant in vcf:
@@ -190,17 +188,11 @@ def variants(args):
                 genotype_array[:,:2] = 1 - genotype_array[:,:2]
                 genotype_array[:,:2][genotype_array[:,:2]==2] = -1
                 variant.genotypes = genotype_array
-                # variant.genotypes = [
-                #     [int(not gt[0]), int(not gt[1]), gt[2]] for gt in variant.genotypes
-                # ]
             elif variant.ploidy == 1:
                 # haploid
                 genotype_array = variant.genotype.array()
                 genotype_array[:,0] = 1 - genotype_array[:,0]
                 genotype_array[:,0][genotype_array[:,0]==2] = -1
-                # variant.genotypes = [
-                #     [int(not gt[0]), gt[1]] for gt in variant.genotypes
-                # ]
             else:
                 raise ValueError(f"invalid ploidy {variant.ploidy}")
 
@@ -214,7 +206,6 @@ def variants(args):
         variant.REF = anc_kmer[ancestor.target]
         variant.ALT = der_kmer[ancestor.target]
         print(variant, end="")
-        # vcf_writer.write_record(variant)
 
         # this line required to exit on a SIGTERM in a pipe, e.g. from head
         signal.signal(signal.SIGPIPE, signal.SIG_DFL)

--- a/mutyper/cli.py
+++ b/mutyper/cli.py
@@ -16,7 +16,7 @@ from mutyper import ancestor
 
 
 def setup_ancestor(args):
-    """Utility for initializing an Ancestor object for use in different 
+    """Utility for initializing an Ancestor object for use in different
     subroutines."""
     return ancestor.Ancestor(
         args.fasta,

--- a/mutyper/cli.py
+++ b/mutyper/cli.py
@@ -186,7 +186,7 @@ def variants(args):
 
             # diploid or haploids
             genotype_array = variant.genotype.array()
-            # checks that all genotype elements are from the set of {-1,0.1}
+            # checks that all genotype elements are from the set of {-1,0,1}
             # each element in the last column is a 0,1 indicator for phasing status
             unique_gts = set(np.unique(genotype_array[:, :-1]))
             if not unique_gts <= set([-1, 0, 1]):

--- a/mutyper/cli.py
+++ b/mutyper/cli.py
@@ -170,13 +170,6 @@ def variants(args):
                 f"invalid ploidy {variant.ploidy}, diploids and haploids only"
             )
 
-        # checks that all genotype elements are from the set of {-1,0,1}
-        # each element in the last column is a 0,1 indicator for phasing status
-        genotype_array = variant.genotype.array()
-        unique_gts = set(np.unique(genotype_array[:, :-1]))
-        if not unique_gts <= set([-1, 0, 1]):
-            raise ValueError(f"invalid genotypes {unique_gts - set([-1,0,1])}")
-
         # mutation type as ancestral kmer and derived kmer
         anc_kmer, der_kmer = ancestor.mutation_type(
             variant.CHROM, variant.start, variant.REF, variant.ALT[0]
@@ -185,6 +178,14 @@ def variants(args):
             continue
         mutation_type = f"{anc_kmer}>{der_kmer}"
         variant.INFO["mutation_type"] = mutation_type
+
+        # checks that all genotype elements are from the set of {-1,0,1}
+        # each element in the last column is a 0,1 indicator for phasing status
+        genotype_array = variant.genotype.array()
+        unique_gts = set(np.unique(genotype_array[:, :-1]))
+        if not unique_gts <= set([-1, 0, 1]):
+            raise ValueError(f"invalid genotypes {unique_gts - set([-1,0,1])}")
+
         # ancestral allele
         AA = ancestor[variant.CHROM][variant.start].seq
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,7 +75,7 @@ def test_spectra_missing_gts(capsys, caplog):
 
 def test_variant_missing_gts_nonstrict(capsys):
     args = argparse.Namespace(
-        fasta="tests/test_data/ancestor.fa", vcf="tests/test_data/snps.missing_gts.variants.vcf", k=3, target=None, sep=":", chrom_pos=1, strand_file=None, strict=False
+        fasta="tests/test_data/ancestor.fa", vcf="tests/test_data/snps.missing_gts.variants.vcf", k=3, target=None, sep=":", chrom_pos=0, strand_file=None, strict=False
     )
     cli.variants(args)
     captured = capsys.readouterr()
@@ -101,7 +101,7 @@ def test_variant_missing_gts_nonstrict(capsys):
 
 def test_variant_missing_gts_strict(capsys):
     args = argparse.Namespace(
-        fasta="tests/test_data/ancestor.fa", vcf="tests/test_data/snps.missing_gts.variants.vcf", k=3, target=None, sep=":", chrom_pos=1, strand_file=None, strict=True
+        fasta="tests/test_data/ancestor.fa", vcf="tests/test_data/snps.missing_gts.variants.vcf", k=3, target=None, sep=":", chrom_pos=0, strand_file=None, strict=True
     )
     cli.variants(args)
     captured = capsys.readouterr()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,10 +72,10 @@ def test_spectra_missing_gts(capsys, caplog):
     pd.testing.assert_frame_equal(df, df_target)
     assert "Ambiguous genotypes found" in caplog.text
 
+
 def test_variant_missing_gts_nonstrict(capsys):
     args = argparse.Namespace(
-        fasta="tests/test_data/ancestor.fa", vcf="tests/test_data/snps.missing_gts.variants.vcf", 
-        k=3, target=None, sep=":", chrom_pos=1, strand_file=None, strict=False
+        fasta="tests/test_data/ancestor.fa", vcf="tests/test_data/snps.missing_gts.variants.vcf", k=3, target=None, sep=":", chrom_pos=1, strand_file=None, strict=False
     )
     cli.variants(args)
     captured = capsys.readouterr()
@@ -98,10 +98,10 @@ def test_variant_missing_gts_nonstrict(capsys):
     )
     pd.testing.assert_frame_equal(df_subset, df_target)
 
+
 def test_variant_missing_gts_strict(capsys):
     args = argparse.Namespace(
-        fasta="tests/test_data/ancestor.fa", vcf="tests/test_data/snps.missing_gts.variants.vcf", 
-        k=3, target=None, sep=":", chrom_pos=1, strand_file=None, strict=True
+        fasta="tests/test_data/ancestor.fa", vcf="tests/test_data/snps.missing_gts.variants.vcf", k=3, target=None, sep=":", chrom_pos=1, strand_file=None, strict=True
     )
     cli.variants(args)
     captured = capsys.readouterr()
@@ -123,6 +123,7 @@ def test_variant_missing_gts_strict(capsys):
         }
     )
     pd.testing.assert_frame_equal(df_subset, df_strict_target)
+
 
 def test_ksfs(capsys):
     args = argparse.Namespace(vcf="tests/test_data/snps.vcf", k=3)
@@ -147,4 +148,3 @@ def test_ksfs_missing_gts():
         ValueError, match=r"different AN [0-9]* and [0-9]* indicates missing genotypes"
     ):
         cli.ksfs(args)
-

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,92 +7,102 @@ import pandas as pd
 import io
 
 
-def test_spectra(capsys):
+# def test_spectra(capsys):
+#     args = argparse.Namespace(
+#         vcf="tests/test_data/snps.vcf", population=False, randomize=False
+#     )
+#     cli.spectra(args)
+#     captured = capsys.readouterr()
+#     df = pd.read_csv(io.StringIO(captured.out), sep="\t", index_col=0)
+#     df_target = pd.DataFrame(
+#         {"ACA>ATA": [0, 1], "ACC>ATC": [1, 0], "ACG>ATG": [1, 1], "ACT>ATT": [2, 0]},
+#         index=pd.Index(["sample1", "sample2"], name="sample"),
+#     )
+#     pd.testing.assert_frame_equal(df, df_target)
+# 
+# 
+# def test_spectra_randomize(capsys):
+#     args = argparse.Namespace(
+#         vcf="tests/test_data/snps.vcf", population=False, randomize=True
+#     )
+#     cli.spectra(args)
+#     captured = capsys.readouterr()
+#     df = pd.read_csv(io.StringIO(captured.out), sep="\t", index_col=0)
+#     # there are two possibilities due to haplotype randomization
+#     df_target1 = pd.DataFrame(
+#         {"ACA>ATA": [0, 1], "ACC>ATC": [1, 0], "ACG>ATG": [1, 0], "ACT>ATT": [1, 0]},
+#         index=pd.Index(["sample1", "sample2"], name="sample"),
+#     )
+#     df_target2 = pd.DataFrame(
+#         {"ACA>ATA": [0, 1], "ACC>ATC": [1, 0], "ACG>ATG": [0, 1], "ACT>ATT": [1, 0]},
+#         index=pd.Index(["sample1", "sample2"], name="sample"),
+#     )
+# 
+#     try:
+#         pd.testing.assert_frame_equal(df, df_target1)
+#     except AssertionError:
+#         pd.testing.assert_frame_equal(df, df_target2)
+# 
+# 
+# def test_spectra_haploid(capsys):
+#     args = argparse.Namespace(
+#         vcf="tests/test_data/snps.haploid.vcf", population=False, randomize=False
+#     )
+#     cli.spectra(args)
+#     captured = capsys.readouterr()
+#     df = pd.read_csv(io.StringIO(captured.out), sep="\t", index_col=0)
+#     df_target = pd.DataFrame(
+#         {"ACA>ATA": [0, 1], "ACC>ATC": [0, 0], "ACG>ATG": [1, 1], "ACT>ATT": [1, 0]},
+#         index=pd.Index(["sample1", "sample2"], name="sample"),
+#     )
+#     pd.testing.assert_frame_equal(df, df_target)
+# 
+# 
+# def test_spectra_missing_gts(capsys, caplog):
+#     args = argparse.Namespace(
+#         vcf="tests/test_data/snps.missing_gts.vcf", population=False, randomize=False
+#     )
+#     cli.spectra(args)
+#     captured = capsys.readouterr()
+#     df = pd.read_csv(io.StringIO(captured.out), sep="\t", index_col=0)
+#     df_target = pd.DataFrame(
+#         {"ACA>ATA": [0, 1], "ACC>ATC": [1, 0], "ACG>ATG": [1, 1], "ACT>ATT": [1, 1]},
+#         index=pd.Index(["sample1", "sample2"], name="sample"),
+#     )
+#     pd.testing.assert_frame_equal(df, df_target)
+#     assert "Ambiguous genotypes found" in caplog.text
+
+
+def test_variant_missing_gts(capsys):
     args = argparse.Namespace(
-        vcf="tests/test_data/snps.vcf", population=False, randomize=False
+        fasta="tests/test_data/ancestor.fa", vcf="tests/test_data/snps.missing_gts.variant.vcf", 
+        k=3, target=None, sep=":", chrom_pos=1, strand_file=None, strict=False
     )
-    cli.spectra(args)
+    cli.variants(args)
     captured = capsys.readouterr()
-    df = pd.read_csv(io.StringIO(captured.out), sep="\t", index_col=0)
-    df_target = pd.DataFrame(
-        {"ACA>ATA": [0, 1], "ACC>ATC": [1, 0], "ACG>ATG": [1, 1], "ACT>ATT": [2, 0]},
-        index=pd.Index(["sample1", "sample2"], name="sample"),
-    )
-    pd.testing.assert_frame_equal(df, df_target)
+    assert 1==2
 
-
-def test_spectra_randomize(capsys):
-    args = argparse.Namespace(
-        vcf="tests/test_data/snps.vcf", population=False, randomize=True
-    )
-    cli.spectra(args)
-    captured = capsys.readouterr()
-    df = pd.read_csv(io.StringIO(captured.out), sep="\t", index_col=0)
-    # there are two possibilities due to haplotype randomization
-    df_target1 = pd.DataFrame(
-        {"ACA>ATA": [0, 1], "ACC>ATC": [1, 0], "ACG>ATG": [1, 0], "ACT>ATT": [1, 0]},
-        index=pd.Index(["sample1", "sample2"], name="sample"),
-    )
-    df_target2 = pd.DataFrame(
-        {"ACA>ATA": [0, 1], "ACC>ATC": [1, 0], "ACG>ATG": [0, 1], "ACT>ATT": [1, 0]},
-        index=pd.Index(["sample1", "sample2"], name="sample"),
-    )
-
-    try:
-        pd.testing.assert_frame_equal(df, df_target1)
-    except AssertionError:
-        pd.testing.assert_frame_equal(df, df_target2)
-
-
-def test_spectra_haploid(capsys):
-    args = argparse.Namespace(
-        vcf="tests/test_data/snps.haploid.vcf", population=False, randomize=False
-    )
-    cli.spectra(args)
-    captured = capsys.readouterr()
-    df = pd.read_csv(io.StringIO(captured.out), sep="\t", index_col=0)
-    df_target = pd.DataFrame(
-        {"ACA>ATA": [0, 1], "ACC>ATC": [0, 0], "ACG>ATG": [1, 1], "ACT>ATT": [1, 0]},
-        index=pd.Index(["sample1", "sample2"], name="sample"),
-    )
-    pd.testing.assert_frame_equal(df, df_target)
-
-
-def test_spectra_missing_gts(capsys, caplog):
-    args = argparse.Namespace(
-        vcf="tests/test_data/snps.missing_gts.vcf", population=False, randomize=False
-    )
-    cli.spectra(args)
-    captured = capsys.readouterr()
-    df = pd.read_csv(io.StringIO(captured.out), sep="\t", index_col=0)
-    df_target = pd.DataFrame(
-        {"ACA>ATA": [0, 1], "ACC>ATC": [1, 0], "ACG>ATG": [1, 1], "ACT>ATT": [1, 1]},
-        index=pd.Index(["sample1", "sample2"], name="sample"),
-    )
-    pd.testing.assert_frame_equal(df, df_target)
-    assert "Ambiguous genotypes found" in caplog.text
-
-
-def test_ksfs(capsys):
-    args = argparse.Namespace(vcf="tests/test_data/snps.vcf", k=3)
-    cli.ksfs(args)
-    captured = capsys.readouterr()
-    df = pd.read_csv(io.StringIO(captured.out), sep="\t", index_col=0)
-    df_target = pd.DataFrame(
-        {
-            "ACA>ATA": [1, 0, 0],
-            "ACC>ATC": [1, 0, 0],
-            "ACG>ATG": [0, 1, 0],
-            "ACT>ATT": [0, 1, 0],
-        },
-        index=pd.Index([1, 2, 3], name="sample_frequency"),
-    )
-    pd.testing.assert_frame_equal(df, df_target)
-
-
-def test_ksfs_missing_gts():
-    args = argparse.Namespace(vcf="tests/test_data/snps.missing_gts.vcf", k=3)
-    with pytest.raises(
-        ValueError, match=r"different AN [0-9]* and [0-9]* indicates missing genotypes"
-    ):
-        cli.ksfs(args)
+# def test_ksfs(capsys):
+#     args = argparse.Namespace(vcf="tests/test_data/snps.vcf", k=3)
+#     cli.ksfs(args)
+#     captured = capsys.readouterr()
+#     df = pd.read_csv(io.StringIO(captured.out), sep="\t", index_col=0)
+#     df_target = pd.DataFrame(
+#         {
+#             "ACA>ATA": [1, 0, 0],
+#             "ACC>ATC": [1, 0, 0],
+#             "ACG>ATG": [0, 1, 0],
+#             "ACT>ATT": [0, 1, 0],
+#         },
+#         index=pd.Index([1, 2, 3], name="sample_frequency"),
+#     )
+#     pd.testing.assert_frame_equal(df, df_target)
+# 
+# 
+# def test_ksfs_missing_gts():
+#     args = argparse.Namespace(vcf="tests/test_data/snps.missing_gts.vcf", k=3)
+#     with pytest.raises(
+#         ValueError, match=r"different AN [0-9]* and [0-9]* indicates missing genotypes"
+#     ):
+#         cli.ksfs(args)
+# 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,102 +7,144 @@ import pandas as pd
 import io
 
 
-# def test_spectra(capsys):
-#     args = argparse.Namespace(
-#         vcf="tests/test_data/snps.vcf", population=False, randomize=False
-#     )
-#     cli.spectra(args)
-#     captured = capsys.readouterr()
-#     df = pd.read_csv(io.StringIO(captured.out), sep="\t", index_col=0)
-#     df_target = pd.DataFrame(
-#         {"ACA>ATA": [0, 1], "ACC>ATC": [1, 0], "ACG>ATG": [1, 1], "ACT>ATT": [2, 0]},
-#         index=pd.Index(["sample1", "sample2"], name="sample"),
-#     )
-#     pd.testing.assert_frame_equal(df, df_target)
-# 
-# 
-# def test_spectra_randomize(capsys):
-#     args = argparse.Namespace(
-#         vcf="tests/test_data/snps.vcf", population=False, randomize=True
-#     )
-#     cli.spectra(args)
-#     captured = capsys.readouterr()
-#     df = pd.read_csv(io.StringIO(captured.out), sep="\t", index_col=0)
-#     # there are two possibilities due to haplotype randomization
-#     df_target1 = pd.DataFrame(
-#         {"ACA>ATA": [0, 1], "ACC>ATC": [1, 0], "ACG>ATG": [1, 0], "ACT>ATT": [1, 0]},
-#         index=pd.Index(["sample1", "sample2"], name="sample"),
-#     )
-#     df_target2 = pd.DataFrame(
-#         {"ACA>ATA": [0, 1], "ACC>ATC": [1, 0], "ACG>ATG": [0, 1], "ACT>ATT": [1, 0]},
-#         index=pd.Index(["sample1", "sample2"], name="sample"),
-#     )
-# 
-#     try:
-#         pd.testing.assert_frame_equal(df, df_target1)
-#     except AssertionError:
-#         pd.testing.assert_frame_equal(df, df_target2)
-# 
-# 
-# def test_spectra_haploid(capsys):
-#     args = argparse.Namespace(
-#         vcf="tests/test_data/snps.haploid.vcf", population=False, randomize=False
-#     )
-#     cli.spectra(args)
-#     captured = capsys.readouterr()
-#     df = pd.read_csv(io.StringIO(captured.out), sep="\t", index_col=0)
-#     df_target = pd.DataFrame(
-#         {"ACA>ATA": [0, 1], "ACC>ATC": [0, 0], "ACG>ATG": [1, 1], "ACT>ATT": [1, 0]},
-#         index=pd.Index(["sample1", "sample2"], name="sample"),
-#     )
-#     pd.testing.assert_frame_equal(df, df_target)
-# 
-# 
-# def test_spectra_missing_gts(capsys, caplog):
-#     args = argparse.Namespace(
-#         vcf="tests/test_data/snps.missing_gts.vcf", population=False, randomize=False
-#     )
-#     cli.spectra(args)
-#     captured = capsys.readouterr()
-#     df = pd.read_csv(io.StringIO(captured.out), sep="\t", index_col=0)
-#     df_target = pd.DataFrame(
-#         {"ACA>ATA": [0, 1], "ACC>ATC": [1, 0], "ACG>ATG": [1, 1], "ACT>ATT": [1, 1]},
-#         index=pd.Index(["sample1", "sample2"], name="sample"),
-#     )
-#     pd.testing.assert_frame_equal(df, df_target)
-#     assert "Ambiguous genotypes found" in caplog.text
-
-
-def test_variant_missing_gts(capsys):
+def test_spectra(capsys):
     args = argparse.Namespace(
-        fasta="tests/test_data/ancestor.fa", vcf="tests/test_data/snps.missing_gts.variant.vcf", 
+        vcf="tests/test_data/snps.vcf", population=False, randomize=False
+    )
+    cli.spectra(args)
+    captured = capsys.readouterr()
+    df = pd.read_csv(io.StringIO(captured.out), sep="\t", index_col=0)
+    df_target = pd.DataFrame(
+        {"ACA>ATA": [0, 1], "ACC>ATC": [1, 0], "ACG>ATG": [1, 1], "ACT>ATT": [2, 0]},
+        index=pd.Index(["sample1", "sample2"], name="sample"),
+    )
+    pd.testing.assert_frame_equal(df, df_target)
+
+
+def test_spectra_randomize(capsys):
+    args = argparse.Namespace(
+        vcf="tests/test_data/snps.vcf", population=False, randomize=True
+    )
+    cli.spectra(args)
+    captured = capsys.readouterr()
+    df = pd.read_csv(io.StringIO(captured.out), sep="\t", index_col=0)
+    # there are two possibilities due to haplotype randomization
+    df_target1 = pd.DataFrame(
+        {"ACA>ATA": [0, 1], "ACC>ATC": [1, 0], "ACG>ATG": [1, 0], "ACT>ATT": [1, 0]},
+        index=pd.Index(["sample1", "sample2"], name="sample"),
+    )
+    df_target2 = pd.DataFrame(
+        {"ACA>ATA": [0, 1], "ACC>ATC": [1, 0], "ACG>ATG": [0, 1], "ACT>ATT": [1, 0]},
+        index=pd.Index(["sample1", "sample2"], name="sample"),
+    )
+
+    try:
+        pd.testing.assert_frame_equal(df, df_target1)
+    except AssertionError:
+        pd.testing.assert_frame_equal(df, df_target2)
+
+
+def test_spectra_haploid(capsys):
+    args = argparse.Namespace(
+        vcf="tests/test_data/snps.haploid.vcf", population=False, randomize=False
+    )
+    cli.spectra(args)
+    captured = capsys.readouterr()
+    df = pd.read_csv(io.StringIO(captured.out), sep="\t", index_col=0)
+    df_target = pd.DataFrame(
+        {"ACA>ATA": [0, 1], "ACC>ATC": [0, 0], "ACG>ATG": [1, 1], "ACT>ATT": [1, 0]},
+        index=pd.Index(["sample1", "sample2"], name="sample"),
+    )
+    pd.testing.assert_frame_equal(df, df_target)
+
+
+def test_spectra_missing_gts(capsys, caplog):
+    args = argparse.Namespace(
+        vcf="tests/test_data/snps.missing_gts.vcf", population=False, randomize=False
+    )
+    cli.spectra(args)
+    captured = capsys.readouterr()
+    df = pd.read_csv(io.StringIO(captured.out), sep="\t", index_col=0)
+    df_target = pd.DataFrame(
+        {"ACA>ATA": [0, 1], "ACC>ATC": [1, 0], "ACG>ATG": [1, 1], "ACT>ATT": [1, 1]},
+        index=pd.Index(["sample1", "sample2"], name="sample"),
+    )
+    pd.testing.assert_frame_equal(df, df_target)
+    assert "Ambiguous genotypes found" in caplog.text
+
+def test_variant_missing_gts_nonstrict(capsys):
+    args = argparse.Namespace(
+        fasta="tests/test_data/ancestor.fa", vcf="tests/test_data/snps.missing_gts.variants.vcf", 
         k=3, target=None, sep=":", chrom_pos=1, strand_file=None, strict=False
     )
     cli.variants(args)
     captured = capsys.readouterr()
-    assert 1==2
+    df = pd.read_csv(io.StringIO(captured.out), skiprows=8, sep="\t")
+    df_info_expand = df["INFO"].str.split(";", expand=True)
+    df_info_expand.columns = ["AN", "AC", "AF", "mutation_type"]
+    df_subset = pd.concat([df[["POS", "REF", "ALT", "sample1", "sample2"]], df_info_expand], axis=1)
+    df_target = pd.DataFrame(
+        {
+            "POS": [2,3,4,7,8,11],
+            "REF": ["A", "A", "C", "C", "C", "A"],
+            "ALT": ["T", "C", "T", "T", "T", "G"],
+            "sample1": ["1|.", ".|0", ".|.", "0|1", "1|1", "0/0"],
+            "sample2": ["1/0", "1/1", "0/1", "1/0", "1|1", "0/0"],
+            "AN": [f"AN={an}" for an in [3, 3, 2, 4, 4, 4]],
+            "AC": [f"AC={ac}" for ac in [2, 2, 1, 2, 4, 0]],
+            "AF": [f"AF={af}" for af in [0.67, 0.666667, 0.5, 0.50, 1, 0]],
+            "mutation_type": [f"mutation_type={type}" for type in ["AAA>ATA", "AAC>ACC", "ACC>ATC", "CCG>CTG", "CCC>CTC", "AAA>AGA"]]
+        }
+    )
+    pd.testing.assert_frame_equal(df_subset, df_target)
 
-# def test_ksfs(capsys):
-#     args = argparse.Namespace(vcf="tests/test_data/snps.vcf", k=3)
-#     cli.ksfs(args)
-#     captured = capsys.readouterr()
-#     df = pd.read_csv(io.StringIO(captured.out), sep="\t", index_col=0)
-#     df_target = pd.DataFrame(
-#         {
-#             "ACA>ATA": [1, 0, 0],
-#             "ACC>ATC": [1, 0, 0],
-#             "ACG>ATG": [0, 1, 0],
-#             "ACT>ATT": [0, 1, 0],
-#         },
-#         index=pd.Index([1, 2, 3], name="sample_frequency"),
-#     )
-#     pd.testing.assert_frame_equal(df, df_target)
-# 
-# 
-# def test_ksfs_missing_gts():
-#     args = argparse.Namespace(vcf="tests/test_data/snps.missing_gts.vcf", k=3)
-#     with pytest.raises(
-#         ValueError, match=r"different AN [0-9]* and [0-9]* indicates missing genotypes"
-#     ):
-#         cli.ksfs(args)
-# 
+def test_variant_missing_gts_strict(capsys):
+    args = argparse.Namespace(
+        fasta="tests/test_data/ancestor.fa", vcf="tests/test_data/snps.missing_gts.variants.vcf", 
+        k=3, target=None, sep=":", chrom_pos=1, strand_file=None, strict=True
+    )
+    cli.variants(args)
+    captured = capsys.readouterr()
+    df = pd.read_csv(io.StringIO(captured.out), skiprows=8, sep="\t")
+    df_info_expand = df["INFO"].str.split(";", expand=True)
+    df_info_expand.columns = ["AN", "AC", "AF", "mutation_type"]
+    df_subset = pd.concat([df[["POS", "REF", "ALT", "sample1", "sample2"]], df_info_expand], axis=1)
+    df_strict_target = pd.DataFrame(
+        {
+            "POS": [2,3,4,11],
+            "REF": ["A", "A", "C", "A"],
+            "ALT": ["T", "C", "T", "G"],
+            "sample1": ["1|.", ".|0", ".|.", "0/0"],
+            "sample2": ["1/0", "1/1", "0/1", "0/0"],
+            "AN": [f"AN={an}" for an in [3, 3, 2, 4]],
+            "AC": [f"AC={ac}" for ac in [2, 2, 1, 0]],
+            "AF": [f"AF={af}" for af in [0.67, 0.666667, 0.5, 0]],
+            "mutation_type": [f"mutation_type={type}" for type in ["AAA>ATA", "AAC>ACC", "ACC>ATC", "AAA>AGA"]]
+        }
+    )
+    pd.testing.assert_frame_equal(df_subset, df_strict_target)
+
+def test_ksfs(capsys):
+    args = argparse.Namespace(vcf="tests/test_data/snps.vcf", k=3)
+    cli.ksfs(args)
+    captured = capsys.readouterr()
+    df = pd.read_csv(io.StringIO(captured.out), sep="\t", index_col=0)
+    df_target = pd.DataFrame(
+        {
+            "ACA>ATA": [1, 0, 0],
+            "ACC>ATC": [1, 0, 0],
+            "ACG>ATG": [0, 1, 0],
+            "ACT>ATT": [0, 1, 0],
+        },
+        index=pd.Index([1, 2, 3], name="sample_frequency"),
+    )
+    pd.testing.assert_frame_equal(df, df_target)
+
+
+def test_ksfs_missing_gts():
+    args = argparse.Namespace(vcf="tests/test_data/snps.missing_gts.vcf", k=3)
+    with pytest.raises(
+        ValueError, match=r"different AN [0-9]* and [0-9]* indicates missing genotypes"
+    ):
+        cli.ksfs(args)
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,53 +73,84 @@ def test_spectra_missing_gts(capsys, caplog):
     assert "Ambiguous genotypes found" in caplog.text
 
 
-def test_variant_missing_gts_nonstrict(capsys):
+def test_variants_missing_gts_nonstrict(capsys):
     args = argparse.Namespace(
-        fasta="tests/test_data/ancestor.fa", vcf="tests/test_data/snps.missing_gts.variants.vcf", k=3, target=None, sep=":", chrom_pos=0, strand_file=None, strict=False
+        fasta="tests/test_data/ancestor.fa",
+        vcf="tests/test_data/snps.missing_gts.variants.vcf",
+        k=3,
+        target=None,
+        sep=":",
+        chrom_pos=0,
+        strand_file=None,
+        strict=False,
     )
     cli.variants(args)
     captured = capsys.readouterr()
     df = pd.read_csv(io.StringIO(captured.out), skiprows=8, sep="\t")
     df_info_expand = df["INFO"].str.split(";", expand=True)
     df_info_expand.columns = ["AN", "AC", "AF", "mutation_type"]
-    df_subset = pd.concat([df[["POS", "REF", "ALT", "sample1", "sample2"]], df_info_expand], axis=1)
+    df_subset = pd.concat(
+        [df[["POS", "REF", "ALT", "sample1", "sample2"]], df_info_expand], axis=1
+    )
     df_target = pd.DataFrame(
         {
-            "POS": [2,3,4,7,8,11],
+            "POS": [2, 3, 4, 7, 8, 11],
             "REF": ["A", "A", "C", "C", "C", "A"],
             "ALT": ["T", "C", "T", "T", "T", "G"],
-            "sample1": ["1|.", ".|0", ".|.", "0|1", "1|1", "0/0"],
-            "sample2": ["1/0", "1/1", "0/1", "1/0", "1|1", "0/0"],
-            "AN": [f"AN={an}" for an in [3, 3, 2, 4, 4, 4]],
-            "AC": [f"AC={ac}" for ac in [2, 2, 1, 2, 4, 0]],
-            "AF": [f"AF={af}" for af in [0.67, 0.666667, 0.5, 0.50, 1, 0]],
-            "mutation_type": [f"mutation_type={type}" for type in ["AAA>ATA", "AAC>ACC", "ACC>ATC", "CCG>CTG", "CCC>CTC", "AAA>AGA"]]
+            "sample1": ["1|.", ".", ".|.", "0|1", "1|1", "0/0"],
+            "sample2": ["1/0", "1", "0/1", "1/0", "1|1", "0/0"],
+            "AN": [f"AN={an}" for an in [3, 1, 2, 4, 4, 4]],
+            "AC": [f"AC={ac}" for ac in [2, 1, 1, 2, 4, 0]],
+            "AF": [f"AF={af}" for af in [0.67, 1, 0.5, 0.50, 1, 0]],
+            "mutation_type": [
+                f"mutation_type={type}"
+                for type in [
+                    "AAA>ATA",
+                    "AAC>ACC",
+                    "ACC>ATC",
+                    "CCG>CTG",
+                    "CCC>CTC",
+                    "AAA>AGA",
+                ]
+            ],
         }
     )
     pd.testing.assert_frame_equal(df_subset, df_target)
 
 
-def test_variant_missing_gts_strict(capsys):
+def test_variants_missing_gts_strict(capsys):
     args = argparse.Namespace(
-        fasta="tests/test_data/ancestor.fa", vcf="tests/test_data/snps.missing_gts.variants.vcf", k=3, target=None, sep=":", chrom_pos=0, strand_file=None, strict=True
+        fasta="tests/test_data/ancestor.fa",
+        vcf="tests/test_data/snps.missing_gts.variants.vcf",
+        k=3,
+        target=None,
+        sep=":",
+        chrom_pos=0,
+        strand_file=None,
+        strict=True,
     )
     cli.variants(args)
     captured = capsys.readouterr()
     df = pd.read_csv(io.StringIO(captured.out), skiprows=8, sep="\t")
     df_info_expand = df["INFO"].str.split(";", expand=True)
     df_info_expand.columns = ["AN", "AC", "AF", "mutation_type"]
-    df_subset = pd.concat([df[["POS", "REF", "ALT", "sample1", "sample2"]], df_info_expand], axis=1)
+    df_subset = pd.concat(
+        [df[["POS", "REF", "ALT", "sample1", "sample2"]], df_info_expand], axis=1
+    )
     df_strict_target = pd.DataFrame(
         {
-            "POS": [2,3,4,11],
+            "POS": [2, 3, 4, 11],
             "REF": ["A", "A", "C", "A"],
             "ALT": ["T", "C", "T", "G"],
-            "sample1": ["1|.", ".|0", ".|.", "0/0"],
-            "sample2": ["1/0", "1/1", "0/1", "0/0"],
-            "AN": [f"AN={an}" for an in [3, 3, 2, 4]],
-            "AC": [f"AC={ac}" for ac in [2, 2, 1, 0]],
-            "AF": [f"AF={af}" for af in [0.67, 0.666667, 0.5, 0]],
-            "mutation_type": [f"mutation_type={type}" for type in ["AAA>ATA", "AAC>ACC", "ACC>ATC", "AAA>AGA"]]
+            "sample1": ["1|.", ".", ".|.", "0/0"],
+            "sample2": ["1/0", "1", "0/1", "0/0"],
+            "AN": [f"AN={an}" for an in [3, 1, 2, 4]],
+            "AC": [f"AC={ac}" for ac in [2, 1, 1, 0]],
+            "AF": [f"AF={af}" for af in [0.67, 1, 0.5, 0]],
+            "mutation_type": [
+                f"mutation_type={type}"
+                for type in ["AAA>ATA", "AAC>ACC", "ACC>ATC", "AAA>AGA"]
+            ],
         }
     )
     pd.testing.assert_frame_equal(df_subset, df_strict_target)

--- a/tests/test_data/ancestor.fa
+++ b/tests/test_data/ancestor.fa
@@ -1,2 +1,2 @@
->foo
+>foo:chr1
 AAACCCgggTTT

--- a/tests/test_data/ancestor.fa
+++ b/tests/test_data/ancestor.fa
@@ -1,2 +1,2 @@
->foo:chr1
+>foo
 AAACCCgggTTT

--- a/tests/test_data/snps.missing_gts.variants.vcf
+++ b/tests/test_data/snps.missing_gts.variants.vcf
@@ -1,15 +1,15 @@
 ##fileformat=VCFv4.2
 ##FILTER=<ID=PASS,Description="All filters passed">
-##contig=<ID=chr1,length=248387328>
+##contig=<ID=foo,length=248387328>
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 ##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
 ##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes">
 ##INFO=<ID=AF,Number=A,Type=Float,Description="Allele frequency in genotypes">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample1	sample2
-chr1	2	.	A	T	30	PASS	AN=3;AC=2;AF=0.67	GT	1|.	1/0
-chr1	3	.	C	A	30	PASS	AN=3;AC=1;AF=0.33	GT	.|1	0/0
-chr1	4	.	T	C	30	PASS	AN=2;AC=1;AF=0.50	GT	.|.	1/0
-chr1	5	.	A	G	30	PASS	AN=4;AC=1;AF=0.50	GT	.|.	1/0
-chr1	7	.	G	A	30	PASS	AN=4;AC=2;AF=0.50	GT	0|1	1/0
-chr1	8	.	A	G	30	PASS	AN=4;AC=0;AF=0.00	GT	0|0	0|0
-chr1	11	.	C	T	30	PASS	AN=4;AC=4;AF=0.50	GT	1/1	1/1
+foo	2	.	A	T	30	PASS	AN=3;AC=2;AF=0.67	GT	1|.	1/0
+foo	3	.	C	A	30	PASS	AN=3;AC=1;AF=0.33	GT	.|1	0/0
+foo	4	.	T	C	30	PASS	AN=2;AC=1;AF=0.50	GT	.|.	1/0
+foo	5	.	A	G	30	PASS	AN=4;AC=1;AF=0.50	GT	.|.	1/0
+foo	7	.	G	A	30	PASS	AN=4;AC=2;AF=0.50	GT	0|1	1/0
+foo	8	.	A	G	30	PASS	AN=4;AC=0;AF=0.00	GT	0|0	0|0
+foo	11	.	C	T	30	PASS	AN=4;AC=4;AF=0.50	GT	1/1	1/1

--- a/tests/test_data/snps.missing_gts.variants.vcf
+++ b/tests/test_data/snps.missing_gts.variants.vcf
@@ -5,8 +5,11 @@
 ##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
 ##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes">
 ##INFO=<ID=AF,Number=A,Type=Float,Description="Allele frequency in genotypes">
-##INFO=<ID=mutation_type,Number=1,Type=Character,Description="ancestral 3-mer mutation type">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample1	sample2
-chr1	2	.	A	T	30	PASS	AN=3;AC=2;AF=0.67;mutation_type=AAG>ATG	GT	1|.	1/0
-chr1	3	.	C	A	30	PASS	AN=3;AC=1;AF=0.33;mutation_type=ACT>AAT	GT	.|1	0/0
-chr1	4	.	T	C	30	PASS	AN=2;AC=1;AF=0.50;mutation_type=ATT>ACT	GT	.|.	1/0
+chr1	2	.	A	T	30	PASS	AN=3;AC=2;AF=0.67	GT	1|.	1/0
+chr1	3	.	C	A	30	PASS	AN=3;AC=1;AF=0.33	GT	.|1	0/0
+chr1	4	.	T	C	30	PASS	AN=2;AC=1;AF=0.50	GT	.|.	1/0
+chr1	5	.	A	G	30	PASS	AN=4;AC=1;AF=0.50	GT	.|.	1/0
+chr1	7	.	G	A	30	PASS	AN=4;AC=2;AF=0.50	GT	0|1	1/0
+chr1	8	.	A	G	30	PASS	AN=4;AC=0;AF=0.00	GT	0|0	0|0
+chr1	11	.	C	T	30	PASS	AN=4;AC=4;AF=0.50	GT	1/1	1/1

--- a/tests/test_data/snps.missing_gts.variants.vcf
+++ b/tests/test_data/snps.missing_gts.variants.vcf
@@ -7,8 +7,8 @@
 ##INFO=<ID=AF,Number=A,Type=Float,Description="Allele frequency in genotypes">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample1	sample2
 foo	2	.	A	T	30	PASS	AN=3;AC=2;AF=0.67	GT	1|.	1/0
-foo	3	.	C	A	30	PASS	AN=3;AC=1;AF=0.33	GT	.|1	0/0
-foo	4	.	T	C	30	PASS	AN=2;AC=1;AF=0.50	GT	.|.	1/0
+foo	3	.	C	A	30	PASS	AN=1;AC=0;AF=0.00	GT	.	0
+foo	4	.	T	C	30	PASS	AN=2;AC=1;AF=1.00	GT	.|.	1/0
 foo	5	.	A	G	30	PASS	AN=4;AC=1;AF=0.50	GT	.|.	1/0
 foo	7	.	G	A	30	PASS	AN=4;AC=2;AF=0.50	GT	0|1	1/0
 foo	8	.	A	G	30	PASS	AN=4;AC=0;AF=0.00	GT	0|0	0|0

--- a/tests/test_data/snps.missing_gts.variants.vcf
+++ b/tests/test_data/snps.missing_gts.variants.vcf
@@ -4,11 +4,9 @@
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 ##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
 ##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes">
-##INFO=<ID=AF,Number=A,Type=Float,Description="Allele count in genotypes">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele frequency in genotypes">
 ##INFO=<ID=mutation_type,Number=1,Type=Character,Description="ancestral 3-mer mutation type">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample1	sample2
-chr1	10	.	C	T	30	PASS	AN=4;AC=1;AF=0.25;mutation_type=ACA>ATA	GT	0|0	1/0
-chr1	20	.	C	T	30	PASS	AN=4;AC=1;AF=0.25;mutation_type=ACC>ATC	GT	0|1	0/0
-chr1	30	.	C	T	30	PASS	AN=3;AC=2;AF=0.67;mutation_type=ACG>ATG	GT	1|.	1/0
-chr1	40	.	C	T	30	PASS	AN=3;AC=1;AF=0.33;mutation_type=ACT>ATT	GT	.|1	0/0
-chr1	50	.	C	T	30	PASS	AN=2;AC=1;AF=0.50;mutation_type=ACT>ATT	GT	.|.	1/0
+chr1	2	.	A	T	30	PASS	AN=3;AC=2;AF=0.67;mutation_type=AAG>ATG	GT	1|.	1/0
+chr1	3	.	C	A	30	PASS	AN=3;AC=1;AF=0.33;mutation_type=ACT>AAT	GT	.|1	0/0
+chr1	4	.	T	C	30	PASS	AN=2;AC=1;AF=0.50;mutation_type=ATT>ACT	GT	.|.	1/0


### PR DESCRIPTION
Some major changes that I have made:
Test cases:
•	Added a unit test for variants alongside a new VCF file that tests for missing genotypes specifically for the variants command (strict + non-strict)
Also modified the `variants` implementation in `cli.py`: 
•	Used `print` statements to create new VCF file instead of `VCFWriter` to allow `stdout` be captured and unit-tested
•	Fixed the bug where missing genotype gets converted to a 0 when the ancestral allele maps to the alternate allele
Closes #36 


