### PR TITLE
numpy implementation for spectra

### DIFF
--- a/mutyper/ancestor.py
+++ b/mutyper/ancestor.py
@@ -68,8 +68,8 @@ class Ancestor(pyfaidx.Fasta):
             self._revcomp_func = self._reverse_strand
 
     def _reverse_strand(self, chrom: str, pos: int):
-        r"""Return ``True`` if ``strand_file`` indicates reverse complementation at
-        this site."""
+        r"""Return ``True`` if ``strand_file`` indicates reverse
+        complementation at this site."""
         closest_idx = bisect.bisect(self.strandedness[chrom][:, 0], pos) - 1
         if closest_idx != -1 and pos < self.strandedness[chrom][closest_idx, 1]:
             return True

--- a/mutyper/cli.py
+++ b/mutyper/cli.py
@@ -268,13 +268,13 @@ def spectra(args):
         spectra_data = defaultdict(lambda: np.zeros_like(vcf.samples, dtype=int))
         if args.randomize:
             for variant in iterate_with_ambiguity_warning():
-                counts = np.array([gt[:-1].count(1) for gt in variant.genotypes])
+                counts = (variant.genotype.array()[:, :-1] == 1).sum(axis=1)
                 rng = np.random.default_rng()
                 random_haplotype = rng.choice(len(counts), p=counts / counts.sum())
                 spectra_data[variant.INFO["mutation_type"]][random_haplotype] += 1.0
         else:
             for variant in iterate_with_ambiguity_warning():
-                counts = np.array([gt[:-1].count(1) for gt in variant.genotypes])
+                counts = (variant.genotype.array()[:, :-1] == 1).sum(axis=1)
                 spectra_data[variant.INFO["mutation_type"]] += counts
 
         spectra = pd.DataFrame(spectra_data, vcf.samples).reindex(

--- a/tests/test_data/snps.vcf
+++ b/tests/test_data/snps.vcf
@@ -6,7 +6,7 @@
 ##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes">
 ##INFO=<ID=mutation_type,Number=1,Type=Character,Description="ancestral 3-mer mutation type">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample1	sample2
-chr1	10	.	C	T	30	PASS	AN=4;AC=1;mutation_type=ACA>ATA	GT	0/0	1/0
+chr1	10	.	C	T	30	PASS	AN=4;AC=1;mutation_type=ACA>ATA	GT	0|0	1/0
 chr1	20	.	C	T	30	PASS	AN=4;AC=1;mutation_type=ACC>ATC	GT	0/1	0/0
-chr1	30	.	C	T	30	PASS	AN=4;AC=2;mutation_type=ACG>ATG	GT	1/0	1/0
-chr1	40	.	C	T	30	PASS	AN=4;AC=2;mutation_type=ACT>ATT	GT	1/1	0/0
+chr1	30	.	C	T	30	PASS	AN=4;AC=2;mutation_type=ACG>ATG	GT	1/0	1|0
+chr1	40	.	C	T	30	PASS	AN=4;AC=2;mutation_type=ACT>ATT	GT	1|1	0/0


### PR DESCRIPTION
Used numpy methods of cyvcf2 (mentioned in issue #108 of cyvcf2) to improve the speed of `spectra`. Running this new implementation on a test dataset reduced the run time from  13 minutes down to 3 minutes.

In addition, also slightly modified the `snps.vcf` file under `tests/test_data` by setting some variants to phased to prevent accidentally adding phased status (`1` for phased) and messing up spectra count.